### PR TITLE
Fix null device fallback and add definition for API

### DIFF
--- a/coverett.c
+++ b/coverett.c
@@ -112,7 +112,7 @@ device_t findDev(bus_t bus, char* name){
 		return dev;
 		}
 	}
-	return (device_t){{0, NULL, NULL, NULL}};
+	return (device_t){0, NULL, NULL, NULL};
 }
 
 list_t getMethods(device_t* device){
@@ -269,3 +269,4 @@ result_t uniInvoke(device_t* dev, char* method, double* numvals, char** strvals,
 		return (result_t){CO_LIST, 0, NULL, ans, NULL};
 	}
 }
+

--- a/coverett.c
+++ b/coverett.c
@@ -96,23 +96,18 @@ device_t proxyDev(bus_t bus, char* id){
 device_t findDev(bus_t bus, char* name){
 	list_t list = getList(bus);
 	char* id = getDevIdByName(list, name);
-	if (id == NULL){
-		device_t dev = {0, NULL, NULL, NULL};
-		return dev;
-	}
+	device_t dev = CO_NULL_DEVICE;
+	if (id == NULL) return dev;
 	int totalnames;
 	char** names = getDevNamesById(list, id, &totalnames);
-	if (names == NULL){
-		device_t dev = {0, NULL, NULL, NULL};
-		return dev;
-	}
+	if (names == NULL) return dev;
 	for (int i = 0; i < totalnames; i++){
 		if (!strcmp(name, names[i])){
-			device_t dev = {1, name, id, bus};
-		return dev;
+			dev = (device_t){1, name, id, bus};
+			return dev;
 		}
 	}
-	return (device_t){0, NULL, NULL, NULL};
+	return CO_NULL_DEVICE;
 }
 
 list_t getMethods(device_t* device){

--- a/coverett.h
+++ b/coverett.h
@@ -10,6 +10,8 @@ extern "C"{
 #include <string.h>
 #include <termios.h>
 #include "cJSON/cJSON.h"
+
+#define CO_NULL_DEVICE (device_t){0, NULL, NULL,NULL}
     
 typedef enum TYPES {
 	CO_ERROR = -1, //Error status


### PR DESCRIPTION
I forgot to remove brackets around the null device returned in findDev (it should never be reached but it's not good to let it there)
And added a definition for null devices to let the user create one without having to fill all the blanks